### PR TITLE
Feature: music snobbery

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ given the above example, we should have a 14 second mp3 with two 7 second clips.
 4. match the index to the nth (3rd) charater of the artist's name
 5. repeat for each clip
 
+## Filtering out artists
+
+to prevent certain artists from appearing in the cipher, pass a space-separated list to the banlist flag, -b
+
+```
+SPOTIFY_CLIENT_ID=xxx SPOTIFY_CLIENT_SECRET=xxx ./popcipher -b Nickelback ICP "hi" 7
+```
+
 ## Using your own songs
 
 to use a set of your own songs, write a file in the format:
@@ -56,7 +64,7 @@ to use a set of your own songs, write a file in the format:
 ]
 ```
 
-then pass the file to pop_cipher command:
+then pass the file to pop_cipher command with the -s flag:
 ```
-SPOTIFY_CLIENT_ID=xxx SPOTIFY_CLIENT_SECRET=xxx ./popcipher "hi" 7 my_songs_file.json
+SPOTIFY_CLIENT_ID=xxx SPOTIFY_CLIENT_SECRET=xxx ./popcipher -s my_songs_file.json "hi" 7
 ```

--- a/pop_cipher
+++ b/pop_cipher
@@ -1,5 +1,23 @@
 #/bin/bash
 
+while getopts ":b:s:" opt; do
+  case ${opt} in
+    b )
+      banlist=$OPTARG
+      ;;
+    s )
+      songsfile=$OPTARG
+      ;;
+    \? )
+      echo "Invalid option: $OPTARG" 1>&2
+      ;;
+    : )
+      echo "Invalid option: $OPTARG requires an argument" 1>&2
+      ;;
+  esac
+done
+shift $((OPTIND -1))
+
 # input text
 text=$1
 
@@ -7,11 +25,14 @@ text=$1
 clip_length=${2:-5}
 
 # custom songs json file, if not, uses the default provided
-songs_file=${3:-data.json}
+songs_file=${songsfile:-data.json}
+
+# banlist - list of space-delimited strings
+banlist=${banlist:-none}
 
 # run the pop_cipher python script to get the cipher and find the
 # spotify preview urls to download
-indexes=$(python pop_cipher.py $text --spotify-client-id=$SPOTIFY_CLIENT_ID --spotify-client-secret=$SPOTIFY_CLIENT_SECRET --songs-json-file $songs_file | awk '{print "curl ", $1, "> pop_cipher_"NR".mp3 && echo "$2}' | bash | awk '{printf "%s.", $1}')
+indexes=$(python pop_cipher.py $text --spotify-client-id=$SPOTIFY_CLIENT_ID --spotify-client-secret=$SPOTIFY_CLIENT_SECRET --songs-json-file $songs_file --banlist $banlist | awk '{print "curl ", $1, "> pop_cipher_"NR".mp3 && echo "$2}' | bash | awk '{printf "%s.", $1}')
 
 # generate the outfile name for the final mp3
 outfile=$(echo "cipher_"$(echo $indexes)"mp3")


### PR DESCRIPTION
- Banlist option flag to prevent certain artists from appearing in the cipher
- Uses flag for songfile too
- Max retries limit (so it doesn't run forever)
- STDERR messaging

If you're _too restrictive_ with the banlist (passing letters "a" and "z"), then ya need to chill out:
```./pop_cipher -b a z "test" 7```

<img width="200" alt="screen shot 2018-04-01 at 1 58 11 pm" src="https://user-images.githubusercontent.com/11144527/38177296-f61721ee-35b3-11e8-847b-c1df4e1b7d0d.png">

Ahhh, just right:
```./pop_cipher -b Nickelback "test" 7```

<img width="125" alt="screen shot 2018-03-08 at 11 10 10 pm" src="https://user-images.githubusercontent.com/11144527/37199205-cd1ad88e-2335-11e8-88fd-51edf3a0bdbb.png">


